### PR TITLE
add `StyleProps` type to remove `theme` from returned function props

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,11 @@ interface IBaseCssValue<T> {
    */
   base?: T;
 }
+
+export type StyleProps<T> = T extends (props: infer R) => any
+  ? R extends { theme?: any } ? Pick<R, Exclude<keyof R, 'theme'>> : R
+  : never;
+
 export type ResponsiveProp<ValueType, BreakPoints = never> = [
   BreakPoints
 ] extends [never]


### PR DESCRIPTION
This adds a `StyleProps` type which will exclude the `theme` prop from the interface of the function returned by `style`. This is useful if TypeScript has trouble inferring that a theme is implicitly passed to a function, e.g. by `styled-components`.