### PR TITLE
fix: consistent media query ordering, fixes #2

### DIFF
--- a/src/__tests__/style.ts
+++ b/src/__tests__/style.ts
@@ -47,9 +47,12 @@ describe('style', () => {
     themeWithBreakpoints = {
       ...theme,
       breakpoints: {
-        large: buildMediaQueryString(50),
-        medium: buildMediaQueryString(40),
+        // disabling tslint to get semantic ordering here instead of alphabetical
+        /* tslint:disable */
         small: buildMediaQueryString(30),
+        medium: buildMediaQueryString(40),
+        large: buildMediaQueryString(50),
+        /* tslint:enable */
       },
     };
   });
@@ -185,6 +188,33 @@ describe('style', () => {
     });
   });
 
+  it('should order media query results based on ordering within `theme.breakpoints` not based on ordering of the responsive object props', () => {
+    const result = style<
+      IColorProps<{ [index: string]: string }>,
+      ITheme,
+      IBreakpoints
+    >({
+      cssProp: 'color',
+      prop: 'input',
+      themeProp: 'colors',
+    })({
+      input: {
+        /* tslint:disable */
+        medium: '#ff0',
+        small: '#fff',
+        large: '#000',
+        /* tslint:enable */
+      },
+      theme: themeWithBreakpoints,
+    });
+
+    expect(Object.keys(result)).toEqual([
+      themeWithBreakpoints.breakpoints.small,
+      themeWithBreakpoints.breakpoints.medium,
+      themeWithBreakpoints.breakpoints.large,
+    ]);
+  });
+
   it('should allow `base` as value for breakpoints to define the base value (without media query) of a property', () => {
     const result = style<
       IColorProps<typeof theme.colors>,
@@ -218,9 +248,9 @@ describe('style', () => {
     });
   });
 
-  it('should return `undefined` for an empty responsive object', () => {
+  it('should put base values in front of all other values', () => {
     const result = style<
-      IColorProps<{ [index: string]: string }>,
+      IColorProps<typeof theme.colors>,
       ITheme,
       IBreakpoints
     >({
@@ -228,10 +258,20 @@ describe('style', () => {
       prop: 'input',
       themeProp: 'colors',
     })({
-      input: {},
+      input: {
+        base: 'red',
+        large: 'red',
+        medium: 'green',
+        small: 'blue',
+      },
       theme: themeWithBreakpoints,
     });
 
-    expect(result).toEqual(undefined);
+    expect(Object.keys(result)).toEqual([
+      'color',
+      themeWithBreakpoints.breakpoints.small,
+      themeWithBreakpoints.breakpoints.medium,
+      themeWithBreakpoints.breakpoints.large,
+    ]);
   });
 });

--- a/src/style.ts
+++ b/src/style.ts
@@ -1,6 +1,11 @@
-import { IStyleOptions, IStyles, ResponsiveObject, WithTheme } from './types';
+import {
+  IStyleOptions,
+  IStyles,
+  ResponsivePropValue,
+  WithTheme,
+} from './types';
 
-const BASE_EMPTY_OBJECT = {};
+const BASE_EMPTY_OBJECT: { [index: string]: string } = {};
 const BREAKPOINTS_BASE_VALUE_KEY = 'base';
 
 export function style<P, T = {}, B = never>({
@@ -8,6 +13,7 @@ export function style<P, T = {}, B = never>({
   prop,
   themeProp,
 }: IStyleOptions<P, T>) {
+  let breakpointKeys: string[];
   return (props: WithTheme<P, T, B>): IStyles | undefined => {
     const propValue = props[prop];
     if (propValue === undefined || propValue === null) {
@@ -32,30 +38,45 @@ export function style<P, T = {}, B = never>({
       // we know that we can only have passed in an object at this point because
       // our types do not permit anything else, so asserting the type here
       // should be fine
-      const styles = finalValue as ResponsiveObject<P, B>;
+      const styles = finalValue as ResponsivePropValue<typeof finalValue, B>;
       const result: IStyles = {};
-      const keys = Object.keys(styles) as Array<keyof typeof style>;
-
-      if (!keys.length) {
-        return undefined;
-      }
-
       const { theme } = props;
       const { breakpoints = BASE_EMPTY_OBJECT } = theme;
       const themeVal = themeValue || BASE_EMPTY_OBJECT;
+      // We rely on the fact that `Object.keys` enumerates keys in the way
+      // they are added to an object. This should be consistent across engines.
+      // In case that a bug is discovered we will have to switch to an implicit
+      // ordering passed in by the consumer.
+      // This also prevents dynamic theme changes. If we want to support this
+      // in the future we have to store `theme` as well and do an equality check
+      // to determine when to re-generate breakpoint keys;
+      const bpkeys =
+        breakpointKeys ||
+        (breakpointKeys = [BREAKPOINTS_BASE_VALUE_KEY].concat(
+          Object.keys(breakpoints),
+        ));
 
-      return keys.reduce((acc, key) => {
-        const value = styles[key];
-        const val = themeVal[value] || value;
-        if (key === BREAKPOINTS_BASE_VALUE_KEY) {
-          acc[cssProp] = val;
-        } else {
-          acc[breakpoints[key]] = {
-            [cssProp]: val,
-          };
-        }
-        return acc;
-      }, result);
+      return (bpkeys as Array<Extract<keyof typeof styles, string>>).reduce(
+        (acc, key) => {
+          // TODO how to get around the cast to any?
+          const value: string = styles[key] as any;
+          const val = themeVal[value] || value;
+          if (value === undefined) {
+            return acc;
+          }
+          if (key === BREAKPOINTS_BASE_VALUE_KEY) {
+            acc[cssProp] = val;
+          } else {
+            // TODO how to get around the cast to any?
+            const breakpointValue: string = breakpoints[key] as any;
+            acc[breakpointValue] = {
+              [cssProp]: val,
+            };
+          }
+          return acc;
+        },
+        result,
+      );
     }
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,14 +9,16 @@ export type StyleProps<T> = T extends (props: infer R) => any
   ? R extends { theme?: any } ? Pick<R, Exclude<keyof R, 'theme'>> : R
   : never;
 
+export type ResponsivePropValue<BreakPoints, ValueType> = {
+  [P in Extract<keyof BreakPoints, string>]?: ValueType
+} &
+  IBaseCssValue<ValueType>;
+
 export type ResponsiveProp<ValueType, BreakPoints = never> = [
   BreakPoints
 ] extends [never]
   ? ValueType
-  :
-      | ValueType
-      | ({ [P in Extract<keyof BreakPoints, string>]?: ValueType } &
-          IBaseCssValue<ValueType>);
+  : ValueType | ResponsivePropValue<BreakPoints, ValueType>;
 
 export type ResponsiveObject<P, B> = {
   [K in keyof P]?: ResponsiveProp<P[K], B>


### PR DESCRIPTION
This PR ensures that media query ordering is consistent based on the defined order within a theme and not the responsive object passed to a component.