### PR TITLE
fix: allow any value for `theme` if no theme is needed, instead of preventing it outright

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,7 @@ export interface IBreakpointTheme<T, B> {
 }
 
 export type ThemeWithBreakpoints<T, B> = [B] extends [never]
-  ? [T] extends [never] ? Partial<ITheme<T>> : ITheme<T>
+  ? [T] extends [never] ? Partial<ITheme<any>> : ITheme<T>
   : IBreakpointTheme<T, B>;
 
 export type WithTheme<P, T, B> = ResponsiveObject<P, B> &


### PR DESCRIPTION
If a style function does not utilize a theme, right now it won't be possible to use it together with a function that requires a theme because one of them requires a theme and the other one prevents a theme from being passed. Changing the type to `any` for a theme that isn't utilized in a function fixes this.